### PR TITLE
Makefile: init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+RUSTUP_TOOLCHAIN ?= nightly
+OUTPUT_DIR ?= dist
+
+# internal values
+RED='\033[0;31m'
+YEL='\033[1;33m'
+NO_COL='\033[0m'
+
+# cool colors!
+STARFYRE="${YEL}star${RED}fyre${NO_COL}"
+
+default: help
+
+# TODO
+# preinstall: # Sets up build environment.
+# install: # Prepares the build evironment, calls preinstall if you have not*.
+# clean: # Removes the preinstall environment
+
+.PHONY: build
+build: # Builds the application to `OUTPUT_DIR`, using `RUSTUP_TOOLCHAIN`
+	@echo "${STARFYRE}: building to ${OUTPUT_DIR}"
+	@mkdir -p ${OUTPUT_DIR}
+	RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN} maturin build --target wasm32-unknown-emscripten -i python3.10 --out ${OUTPUT_DIR}
+	@echo "${STARFYRE}: build available @ ${OUTPUT_DIR}/"
+
+
+.PHONY: dev
+dev: # Runs `test-application` built with the current `OUTPUT_DIR` starfyre
+# FIXME - this works because of a hack in how ./test-application/public/index.html 
+# `micro-pip` installs the .whl's, version mismatches will lead to unexpected result.
+	@echo "${STARFYRE}: packaging dev-starfyre @ ${OUTPUT_DIR}/ into ./test-application"
+	@cp -R ${OUTPUT_DIR}/* ./test-application/starfyre-dist/
+	@cd test-application && $(MAKE) dev
+
+
+.PHONY: in-dev
+in-dev: # Builds `starfyre` and injects into a running `test-application`
+# similar to `dev`, but builds first
+	@$(MAKE) build
+	@$(MAKE) dev
+
+
+.PHONY: help
+help: # Shows `make` help commands and ARGS
+	@echo "Welcome to ${STARFYRE}!"
+	@echo "make [command]"
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+	@echo "make [command] ARGS"
+	@grep -E '^[a-zA-Z0-9 _-]+[?].*'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d'?')\033[00m:$$(echo $$l | cut -f 2- -d'?')\n"; done

--- a/test-application/Makefile
+++ b/test-application/Makefile
@@ -1,0 +1,60 @@
+# internal values
+RED='\033[0;31m'
+YEL='\033[1;33m'
+WHITE='\033[0;37m'
+NO_COL='\033[0m'
+
+# cool colors!
+STARFYRE="${YEL}star${RED}fyre${NO_COL}"
+
+default: help
+
+
+.PHONY: preinstall
+preinstall: # Sets up python virtual environment
+	@echo "create-${STARFYRE}-app: preparing python virtual environment (venv)"
+	@python3.10 -m venv .venv
+	@echo "create-${STARFYRE}-app: preinstall environment ready"
+
+
+.PHONY: install
+install: # Prepares the build environment, calls preinstall if you have not*
+	@[ -e .venv/bin/python ] || $(MAKE) preinstall
+	@echo "create-${STARFYRE}-app: installing dev dependencies"
+	@.venv/bin/python -m pip install -r requirements-dev.txt
+	@echo "create-${STARFYRE}-app: dev environment prepared"
+
+.PHONY: build
+build: # Builds the test-application
+	@echo "create-${STARFYRE}-app: building"
+	@.venv/bin/python -m poetry build
+	@echo "create-${STARFYRE}-app: build complete"
+
+
+.PHONY: start
+start: # Starts the test-application
+	@echo  "create-${STARFYRE}-app @ ${WHITE}http://localhost:8000/public/${NO_COL}"
+	@.venv/bin/python -m http.server
+
+
+.PHONY: dev
+dev: # Builds and starts the application
+	@[ -e .venv/bin/python ] || $(MAKE) install
+	@$(MAKE) build
+	@$(MAKE) start
+
+
+.PHONY: clean
+clean: # Removes the preinstall environment
+	@echo "create-${STARFYRE}-app: removing preinstall environment"
+	@rm -rf .venv/
+	@echo "create-${STARFYRE}-app: Done. please run make install now"
+
+
+.PHONY: help
+help: # Shows `make` help commands and ARGS
+	@echo "Welcome to create-${STARFYRE}-app!"
+	@echo "make [command]"
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+	@echo "make [command] ARGS"
+	@grep -E '^[a-zA-Z0-9 _-]+[?].*'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d'?')\033[00m:$$(echo $$l | cut -f 2- -d'?')\n"; done

--- a/test-application/package.json
+++ b/test-application/package.json
@@ -4,7 +4,7 @@
   "description": "Create Starfyre App",
   "main": "index.js",
   "scripts": {
-    "start": "poetry build && python -m http.server"
+    "start": "make dev"
   },
   "author": "Sanskar Jethi",
   "license": "MIT"

--- a/test-application/requirements-dev.txt
+++ b/test-application/requirements-dev.txt
@@ -1,0 +1,2 @@
+setuptools
+poetry


### PR DESCRIPTION
Initial makefile workflow.

(1/n) Towards https://github.com/sansyrox/starfyre/issues/11

Have created Makefiles in both the root of the repo and in `./test-application` to facilitate a developer incremental workflow.

Have also created in both `Makefile`s:
- `make help`'s (default) to guide the dev.
-  some helpful self-target calling (i.e preparing the build environment if the user has not).
- pretty colours.

Some discovered/existing limitations, which are not intended for this PR, and perhaps follow ups:
- improving the `make build` (and related command, install, preinstall, clean) of the root project, which currently have no-local knowledge of how to build.
- updating `README.md`'s to encourage `make` workflow, think the above should be done first.
- improving how the local built wheel of starfyre is injected into the ./test-application, version numbers currently break this behaviour.

```
make help
Welcome to starfyre!
make [command]
build: Builds the application to `OUTPUT_DIR`, using `RUSTUP_TOOLCHAIN`
dev: Runs `test-application` built with the current `OUTPUT_DIR` starfyre
in-dev: Builds `starfyre` and injects into a running `test-application`
help: Shows `make` help commands and ARGS
```

Example worflow:

```
make dev
starfyre: packaging dev-starfyre @ dist/ into ./test-application
create-starfyre-app: building
Building create-starfyre-app (0.1.0)
  - Building sdist
  - Built create_starfyre_app-0.1.0.tar.gz
  - Building wheel
  - Built create_starfyre_app-0.1.0-py3-none-any.whl
create-starfyre-app: build complete
create-starfyre-app @ ''http://localhost:8000/public/''
```
