### PR TITLE
Makefile: build starfyre

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,9 @@ def Component():
 
 ## Developing Locally
 
-1. Create a `venv` - `python3 -m venv venv`
-2. Source in the `venv` - `source venv/bin/activate`
-3. Install maturin - `pip3 install maturin`
-4. Run the build - `make in-dev`
+1. `make in-dev`
+
+For more flexibility, see `make help`
 
 ## Feedback
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,14 @@
 [build-system]
-requires = ["maturin>=0.12,<0.13"]
+requires = ["maturin>=0.12"]
 build-backend = "maturin"
+
+[tool.maturin]
+python-source = "starfyre"
 
 [project]
 name = "starfyre"
 requires-python = ">=3.6"
+dependencies=[]
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+setuptools
+maturin>=0.14


### PR DESCRIPTION
Updates the Makefile to `make build` the `starfyre` source. 

`make in-dev` will now actually build the current `starfyre` and make it available in `test-application`.

There are still a few limitations:
 - requiring to have `python`, `rust`, `cargo`, `emcc` on your machine but good place to start.
 - Not sure how to sync emscripten versions. I think pyo3 needs to be built with the same version for loading the `starfyre-0.4.1-cp310-cp310-**emscripten_3_1_27**_wasm32.whl` wheel

Follow ups, remove files:
`package.json` - unused.
`cargo.lock` - iiuc, this shouldnt be in the source control for libraries.
`poetry.lock` - we dont seem to use poetry at the moment?
`build.sh` - unused. 
