### PR TITLE
fix: load the last starfyre if we can

### DIFF
--- a/test-application/pyproject.toml
+++ b/test-application/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-starfyre = "^0.3.0"
+starfyre = ">0.3.0"
 
 
 [build-system]


### PR DESCRIPTION
Error in the `test-application` when installing a newer starfyre wheel.

Updated to just install the latest if we can. we're in development afterall.

```
File "/lib/python3.10/site-packages/micropip/_micropip.py", line 364, in check_version_satisfied
    raise ValueError(
ValueError: Requested 'starfyre<0.4.0,>=0.3.0', but starfyre==0.4.1 is already installed
```

Docs on version constraints which were causing this:
 https://python-poetry.org/docs/dependency-specification/ 