### PR TITLE
fix: remove tool.maturin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,6 @@
 requires = ["maturin>=0.12"]
 build-backend = "maturin"
 
-[tool.maturin]
-python-source = "starfyre"
 
 [project]
 name = "starfyre"


### PR DESCRIPTION
Fix: Did not mean to commit this.

The project still builds but will give you an `ImportError` at runtime, as described here: https://github.com/PyO3/maturin#mixed-rustpython-projects with the correct stucture/fix.
