### PR TITLE
Add prerequisites for installation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ Starfyre is a library that allows you to build reactive frontends using only Pyt
 
 
 
-## 📦 Installation:
+## 📦 Development Setup:
+
+### Prerequisites
+
+Install [Rust](https://www.rust-lang.org/tools/install) which includes Cargo package manager.
+
+
+### Installation
 
 ```
 pip install starfyre


### PR DESCRIPTION
When installing Starfyre, I realized that the installation requires Rust/Cargo, but it isn't mentioned in the REAMDE.md file (which leads to the error shown in the picture).

I think it could be beneficial to mention it as a prerequisite😊
![starfyre-rust](https://github.com/sparckles/starfyre/assets/141247677/02d59846-f14d-4b18-b56c-bba4b84bacc8)
